### PR TITLE
Add minimal Apps SDK real-estate template scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Real Estate Apps SDK 최소 템플릿
+
+OpenAI Apps SDK quickstart 흐름을 참고한 **최소 골격**입니다.
+
+## 포함 내용
+- MCP 서버 (`/mcp`) + 헬스체크 (`/health`)
+- 샘플 툴 `search_listings`
+- 샘플 UI 리소스 `ui://widget/listings.html`
+
+## 실행
+```bash
+npm install
+npm run dev
+```
+
+기본 포트는 `3000`이며, 엔드포인트는 다음과 같습니다.
+- MCP: `http://localhost:3000/mcp`
+- Health: `http://localhost:3000/health`
+
+## Apps 등록 시 체크리스트
+1. 공개 URL로 배포 후 `/mcp`를 외부에서 접근 가능하게 구성
+2. 인증(OAuth/API key) 정책 추가
+3. 실제 DB/검색 API 연동으로 `search_listings` 구현 교체
+4. `openai/outputTemplate`에 연결된 위젯 HTML 보안 점검
+
+## 참고
+- 현재 코드는 **샘플 데이터 기반 템플릿**입니다.
+- Apps SDK 문서 버전에 따라 transport/메타 키가 변경될 수 있어 최신 문서와 함께 검증하세요.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "realestate-apps-sdk-template",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "OpenAI Apps SDK 최소 템플릿 골격 (real-estate demo)",
+  "scripts": {
+    "dev": "node src/server.js",
+    "start": "node src/server.js",
+    "check": "node --check src/server.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.17.0",
+    "express": "^4.21.2",
+    "zod": "^3.24.1"
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,117 @@
+import express from "express";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+const PORT = Number(process.env.PORT || 3000);
+
+const server = new McpServer({
+  name: "realestate-app",
+  version: "0.1.0"
+});
+
+server.registerResource(
+  "listings-widget",
+  "ui://widget/listings.html",
+  {},
+  async () => ({
+    contents: [
+      {
+        uri: "ui://widget/listings.html",
+        mimeType: "text/html",
+        text: `<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>매물 결과</title>
+    <style>
+      body { font-family: ui-sans-serif, system-ui, sans-serif; margin: 0; padding: 12px; }
+      .card { border: 1px solid #e5e7eb; border-radius: 10px; padding: 10px; margin-bottom: 8px; }
+      .price { font-weight: 700; }
+      .meta { color: #6b7280; font-size: 13px; }
+    </style>
+  </head>
+  <body>
+    <div id="root">데이터를 불러오는 중...</div>
+    <script>
+      const data = window?.openai?.toolOutput?.structuredContent;
+      const root = document.getElementById("root");
+      if (!data?.listings?.length) {
+        root.textContent = "표시할 매물이 없습니다.";
+      } else {
+        root.innerHTML = data.listings.map(function(item) {
+          return "<div class=\"card\">" +
+            "<div class=\"price\">" + item.price + "</div>" +
+            "<div>" + item.title + "</div>" +
+            "<div class=\"meta\">" + item.city + " · " + item.type + "</div>" +
+          "</div>";
+        }).join("");
+      }
+    </script>
+  </body>
+</html>`
+      }
+    ]
+  })
+);
+
+server.registerTool(
+  "search_listings",
+  {
+    title: "매물 검색",
+    description: "도시와 거래 유형(월세/전세/매매)으로 샘플 매물을 조회합니다.",
+    inputSchema: {
+      city: z.string().describe("예: 서울, 부산"),
+      type: z.enum(["월세", "전세", "매매"]).default("월세")
+    },
+    _meta: {
+      "openai/outputTemplate": "ui://widget/listings.html",
+      "openai/toolInvocation/invoking": "매물 조회 중...",
+      "openai/toolInvocation/invoked": "매물 조회 완료"
+    }
+  },
+  async ({ city, type }) => {
+    const listings = [
+      { title: "역세권 오피스텔", city, type, price: "보증금 1,000 / 월 70" },
+      { title: "신축 투룸", city, type, price: "보증금 2,000 / 월 95" },
+      { title: "채광 좋은 원룸", city, type, price: "보증금 500 / 월 55" }
+    ];
+
+    return {
+      content: [{ type: "text", text: `${city} ${type} 매물 ${listings.length}건을 찾았습니다.` }],
+      structuredContent: { listings }
+    };
+  }
+);
+
+const app = express();
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ ok: true, name: "realestate-app", version: "0.1.0" });
+});
+
+app.post("/mcp", async (req, res) => {
+  try {
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined
+    });
+
+    res.on("close", () => {
+      transport.close();
+    });
+
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (error) {
+    console.error("MCP request error", error);
+    if (!res.headersSent) {
+      res.status(500).json({ error: "MCP request failed" });
+    }
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`[realestate-app] MCP endpoint listening on http://localhost:${PORT}/mcp`);
+});


### PR DESCRIPTION
### Motivation
- Provide a minimal, runnable scaffold for an OpenAI Apps SDK style app that demonstrates an MCP endpoint, a UI resource, and a sample tool for a real-estate demo based on the Apps SDK quickstart.
- Make it easy to run locally and to replace the sample data with real APIs when integrating into production.
- Include a simple checklist and run instructions to aid deployment and app registration.

### Description
- Add `package.json` with `dev`, `start`, and `check` scripts and basic dependencies (`@modelcontextprotocol/sdk`, `express`, `zod`).
- Add `src/server.js` which creates a `McpServer`, registers a UI resource (`ui://widget/listings.html`) and a sample tool `search_listings` that returns `structuredContent` and an `openai/outputTemplate` meta mapping, and exposes `/mcp` and `/health` endpoints.
- Add `README.md` describing how to run the scaffold (`npm install`, `npm run dev`), the endpoints, and a production checklist for Apps registration.

### Testing
- Ran `node --check src/server.js` which passed after fixing an embedded-template syntax issue (syntax check succeeded).
- Attempted `npm install` in this environment but it failed due to a `403 Forbidden` response from the npm registry for `@modelcontextprotocol/sdk`, so dependency installation/runtime verification could not complete.
- Automated syntax check (`npm run check`) returned success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c081fc5a4833289df8f0889f6c486)