### PR TITLE
fix: restore typecheck (MCP server) and add date-based collection entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ npm run collect -- 202401
 npm run collect -- 202401 202412
 ```
 
+
+날짜 기반(권장, 크론잡 용도):
+
+```bash
+# 초기 1회 전체 수집 (예: 2024년 전체)
+npm run collect:date -- --mode bootstrap --from 2024-01-01 --to 2024-12-31
+
+# 증분 수집 (월 1회 크론: 해당 월만)
+npm run collect:date -- --mode incremental --from 2025-01-01
+```
+
 ### 4.4 MCP 서버 실행
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "check": "tsc --noEmit",
     "start:mcp": "node --enable-source-maps dist/mcp/server.js",
     "collect": "tsx src/scripts/collectAndStore.ts",
+    "collect:date": "tsx src/scripts/collectByDate.ts",
     "dev:mcp": "tsx src/mcp/server.ts",
     "start:apps": "node --enable-source-maps dist/apps/quickstart/server.js",
     "dev:apps": "tsx src/apps/quickstart/server.ts",

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,21 +1,16 @@
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { firestore } from "../lib/firebase.js";
 
-const server = new Server(
-  {
-    name: "kr-realestate-mcp",
-    version: "0.1.0",
-  },
-  {
-    capabilities: {
-      tools: {},
-    },
-  },
-);
+const server = new McpServer({
+  name: "kr-realestate-mcp",
+  version: "0.1.0",
+});
 
-const searchSchema = {
+const wonToEok = (amount: number): string => `${(amount / 100_000_000).toFixed(2)}억`;
+
+const searchInputSchema = {
   region: z.enum(["서울", "경기", "인천"]).optional(),
   districtCode: z.string().optional(),
   apartmentName: z.string().optional(),
@@ -23,12 +18,13 @@ const searchSchema = {
   toYm: z.string().regex(/^\d{6}$/),
 };
 
-const wonToEok = (amount: number): string => `${(amount / 100_000_000).toFixed(2)}억`;
-
-server.tool(
+server.registerTool(
   "search_realestate_trends",
-  "수도권(서울/경기/인천) 아파트 월별 실거래가 통계를 조회하고 간단한 추세 시각화를 제공합니다.",
-  searchSchema,
+  {
+    title: "수도권 실거래가 추이 조회",
+    description: "수도권(서울/경기/인천) 아파트 월별 실거래가 통계를 조회하고 간단한 추세 시각화를 제공합니다.",
+    inputSchema: searchInputSchema,
+  },
   async (input) => {
     let query = firestore.collection("apt_monthly_aggregates")
       .where("yearMonth", ">=", input.fromYm)
@@ -55,7 +51,7 @@ server.tool(
       return {
         content: [
           {
-            type: "text",
+            type: "text" as const,
             text: "조건에 맞는 수도권 실거래가 집계 데이터가 없습니다.",
           },
         ],
@@ -78,7 +74,7 @@ server.tool(
     return {
       content: [
         {
-          type: "text",
+          type: "text" as const,
           text: [
             "[수도권 실거래가 조회 결과]",
             summary,
@@ -98,14 +94,17 @@ server.tool(
   },
 );
 
-server.tool(
+server.registerTool(
   "get_latest_transaction_examples",
-  "조건에 맞는 최근 실거래 개별 사례를 조회합니다(수도권 한정).",
   {
-    region: z.enum(["서울", "경기", "인천"]).optional(),
-    districtCode: z.string().optional(),
-    apartmentName: z.string().optional(),
-    limit: z.number().min(1).max(30).default(10),
+    title: "수도권 최신 거래 사례 조회",
+    description: "조건에 맞는 최근 실거래 개별 사례를 조회합니다(수도권 한정).",
+    inputSchema: {
+      region: z.enum(["서울", "경기", "인천"]).optional(),
+      districtCode: z.string().optional(),
+      apartmentName: z.string().optional(),
+      limit: z.number().int().min(1).max(30).default(10),
+    },
   },
   async (input) => {
     let query = firestore.collection("apt_transactions").orderBy("tradedAt", "desc").limit(input.limit);
@@ -120,7 +119,7 @@ server.tool(
     return {
       content: [
         {
-          type: "text",
+          type: "text" as const,
           text: rows.length
             ? rows
                 .map(

--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -5,9 +5,12 @@
 
 ## 핵심 파일
 - `collectAndStore.ts`: 월 범위 계산, 지역 반복 수집, 저장 실행
+- `collectByDate.ts`: 날짜(`YYYY-MM-DD`) 기반 수집(초기 전체/증분 크론 대응)
 
 ## 입력/출력
-- 입력: CLI `startYm`, `endYm`
+- 입력: CLI
+  - `collectAndStore.ts`: `startYm`, `endYm`
+  - `collectByDate.ts`: `--mode`, `--from`, `--to?`
 - 출력: 콘솔 운영 로그 + Firestore upsert
 
 ## 이 디렉토리만 수정하면 되는 경우

--- a/src/scripts/collectByDate.ts
+++ b/src/scripts/collectByDate.ts
@@ -1,0 +1,121 @@
+import { collectTradesByMonth } from "../collector/molitCollector.js";
+import { seoulMetroDistricts } from "../lib/config.js";
+import { makeMonthlyAggregates, upsertMonthlyAggregates, upsertTrades } from "../lib/store.js";
+
+type Mode = "bootstrap" | "incremental";
+
+type CliArgs = {
+  mode: Mode;
+  from: string;
+  to: string;
+};
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const parseArgValue = (args: string[], key: string): string | undefined => {
+  const index = args.indexOf(key);
+  if (index === -1) return undefined;
+  return args[index + 1];
+};
+
+const assertValidDate = (value: string, key: string): void => {
+  if (!DATE_RE.test(value)) {
+    throw new Error(`${key} must be YYYY-MM-DD format. received=${value}`);
+  }
+
+  const date = new Date(`${value}T00:00:00.000Z`);
+  if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== value) {
+    throw new Error(`${key} is not a valid date. received=${value}`);
+  }
+};
+
+const normalizeToYm = (date: string): string => date.slice(0, 7).replace("-", "");
+
+const getYearMonths = (startYm: string, endYm: string): string[] => {
+  const out: string[] = [];
+  let year = Number(startYm.slice(0, 4));
+  let month = Number(startYm.slice(4, 6));
+  const endYear = Number(endYm.slice(0, 4));
+  const endMonth = Number(endYm.slice(4, 6));
+
+  while (year < endYear || (year === endYear && month <= endMonth)) {
+    out.push(`${year}${String(month).padStart(2, "0")}`);
+    month += 1;
+    if (month > 12) {
+      month = 1;
+      year += 1;
+    }
+  }
+
+  return out;
+};
+
+const parseCliArgs = (args: string[]): CliArgs => {
+  const modeRaw = parseArgValue(args, "--mode") ?? "incremental";
+  if (modeRaw !== "bootstrap" && modeRaw !== "incremental") {
+    throw new Error("--mode must be one of: bootstrap | incremental");
+  }
+
+  const from = parseArgValue(args, "--from");
+
+  if (!from) {
+    throw new Error("--from is required. example: --from 2024-01-01");
+  }
+
+  assertValidDate(from, "--from");
+
+  if (modeRaw === "bootstrap") {
+    const to = parseArgValue(args, "--to");
+    if (!to) {
+      throw new Error("bootstrap mode requires --to. example: --to 2024-12-31");
+    }
+    assertValidDate(to, "--to");
+
+    if (from > to) {
+      throw new Error("--from must be less than or equal to --to");
+    }
+
+    return { mode: modeRaw, from, to };
+  }
+
+  const to = parseArgValue(args, "--to") ?? from;
+  assertValidDate(to, "--to");
+
+  if (from > to) {
+    throw new Error("--from must be less than or equal to --to");
+  }
+
+  return {
+    mode: modeRaw,
+    from,
+    to,
+  };
+};
+
+const main = async (): Promise<void> => {
+  const cliArgs = parseCliArgs(process.argv.slice(2));
+  const startYm = normalizeToYm(cliArgs.from);
+  const endYm = normalizeToYm(cliArgs.to);
+  const months = getYearMonths(startYm, endYm);
+
+  console.log(`[START] mode=${cliArgs.mode} from=${cliArgs.from} to=${cliArgs.to} months=${months.join(",")}`);
+
+  for (const district of seoulMetroDistricts) {
+    for (const ym of months) {
+      const trades = await collectTradesByMonth(district.lawdCd, ym, district.region);
+      await upsertTrades(trades);
+      const aggregates = makeMonthlyAggregates(trades);
+      await upsertMonthlyAggregates(aggregates);
+      console.log(
+        `[INGEST] mode=${cliArgs.mode} ${district.region}/${district.lawdCd}/${ym}: trades=${trades.length}, monthlyAgg=${aggregates.length}`,
+      );
+    }
+  }
+
+  console.log("[DONE] collectByDate completed");
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Restore failing TypeScript checks caused by old MCP server API usage so CI/local `tsc` can pass.  
- Provide a date-oriented ingestion entrypoint for initial backfills and monthly incremental cron jobs.  
- Update docs and npm scripts so operators can run the new entrypoint and understand usage.

### Description
- Migrated `src/mcp/server.ts` from the old `Server`/`tool(...)` usage to `McpServer` and `registerTool(...)` to align with `@modelcontextprotocol/sdk` types and fix TypeScript errors.  
- Added `src/scripts/collectByDate.ts`, which accepts `--mode` (`bootstrap` | `incremental`) and `--from`/`--to` in `YYYY-MM-DD` format, validates inputs, converts to `YYYYMM` months, and invokes the existing monthly collectors and upserts.  
- Added `collect:date` npm script in `package.json` and updated `README.md` and `src/scripts/README.md` with examples for bootstrap and incremental runs and recommended verification commands (e.g. `npm run collect:date -- --mode bootstrap --from 2024-01-01 --to 2024-12-31`).

### Testing
- Ran `npm run check` (`tsc --noEmit`) and it now succeeds after the MCP server migration.  
- Executed `npm run collect:date -- --mode incremental --from 2025-01-01` which failed to run in this environment due to missing runtime environment variables (`FIREBASE_PROJECT_ID` and `MOLIT_SERVICE_KEY`), so live ingestion could not be completed here.  
- No other automated tests were modified; with required environment variables present you can validate ingestion by running the above `collect:date` commands and observing `[INGEST]` logs and Firestore updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ceecb57a48332b4e49da9fa619aee)