### PR TITLE
Add GitHub Actions workflow to run manual data-collection tests

### DIFF
--- a/.github/workflows/test-data-collection.yml
+++ b/.github/workflows/test-data-collection.yml
@@ -1,0 +1,64 @@
+name: Test Data Collection
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "collectByDate mode"
+        required: true
+        default: "incremental"
+        type: choice
+        options:
+          - incremental
+          - bootstrap
+      from:
+        description: "Start date (YYYY-MM-DD)"
+        required: true
+        default: "2025-01-01"
+      to:
+        description: "End date (YYYY-MM-DD, required for bootstrap)"
+        required: false
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+      FIREBASE_CLIENT_EMAIL: ${{ secrets.FIREBASE_CLIENT_EMAIL }}
+      FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
+      MOLIT_SERVICE_KEY: ${{ secrets.MOLIT_SERVICE_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run check
+
+      - name: Validate secrets
+        run: |
+          required=(FIREBASE_PROJECT_ID FIREBASE_CLIENT_EMAIL FIREBASE_PRIVATE_KEY MOLIT_SERVICE_KEY)
+          for key in "${required[@]}"; do
+            if [ -z "${!key}" ]; then
+              echo "::error::Missing secret: $key"
+              exit 1
+            fi
+          done
+
+      - name: Run collectByDate
+        run: |
+          set -euo pipefail
+          ARGS=(--mode "${{ github.event.inputs.mode }}" --from "${{ github.event.inputs.from }}")
+          if [ -n "${{ github.event.inputs.to }}" ]; then
+            ARGS+=(--to "${{ github.event.inputs.to }}")
+          fi
+          npm run collect:date -- "${ARGS[@]}"

--- a/README.md
+++ b/README.md
@@ -138,6 +138,24 @@ npm run dev:apps
 - 파일: `src/apps/quickstart/server.ts`
 - 포함 내용: `openai/outputTemplate` 메타데이터, 위젯 HTML 리소스(`ui://...`), 수도권 월별 추이 조회 도구
 
+
+### 4.6 GitHub Actions로 수집 테스트
+
+수동 실행 워크플로우: `.github/workflows/test-data-collection.yml`
+
+1) 저장소 **Settings → Secrets and variables → Actions**에 아래 시크릿을 추가
+- `FIREBASE_PROJECT_ID`
+- `FIREBASE_CLIENT_EMAIL`
+- `FIREBASE_PRIVATE_KEY`
+- `MOLIT_SERVICE_KEY`
+
+> 참고: **Codespaces secrets와 Actions secrets는 별개**입니다. Actions에서 실행하려면 반드시 Actions 시크릿에 동일 키를 등록해야 합니다.
+
+2) GitHub 탭에서 **Actions → Test Data Collection → Run workflow** 실행
+- `mode`: `incremental` 또는 `bootstrap`
+- `from`: `YYYY-MM-DD`
+- `to`: bootstrap일 때만 입력
+
 ---
 
 ## 5) Firestore 스키마


### PR DESCRIPTION
### Motivation
- Provide a reproducible, on-demand way to run the data collection pipeline in GitHub Actions using repository secrets. 
- Document how to configure Actions secrets (distinct from Codespaces secrets) and how to trigger the workflow.

### Description
- Added `.github/workflows/test-data-collection.yml` which exposes a `workflow_dispatch` UI with inputs `mode`, `from`, and `to` and runs the collection flow. 
- The workflow installs dependencies, runs `npm run check`, validates required Actions secrets, and invokes `npm run collect:date` with the provided inputs. 
- Updated `README.md` to document the new `Test Data Collection` workflow and list the required Actions secrets (`FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`, `MOLIT_SERVICE_KEY`). 
- All changes were committed to the working branch.

### Testing
- Ran `npm run check` (TypeScript `tsc --noEmit`) and it completed successfully. 
- No additional automated tests were added or run in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d56e8f9b48332af3b491e800e4412)