### PR TITLE
Load workflow secrets from single PROD_SECRET entry

### DIFF
--- a/.github/workflows/test-data-collection.yml
+++ b/.github/workflows/test-data-collection.yml
@@ -24,23 +24,58 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
-      FIREBASE_CLIENT_EMAIL: ${{ secrets.FIREBASE_CLIENT_EMAIL }}
-      FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
-      MOLIT_SERVICE_KEY: ${{ secrets.MOLIT_SERVICE_KEY }}
+      PROD_SECRET: ${{ secrets.PROD_SECRET }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate secrets
+      - name: Load and validate secrets
         run: |
+          set -euo pipefail
+
+          if [ -z "${PROD_SECRET:-}" ]; then
+            echo "::error::Missing secret: PROD_SECRET"
+            echo "::error::Set this under Settings > Secrets and variables > Actions."
+            exit 1
+          fi
+
+          declare -A parsed
+          while IFS= read -r line || [ -n "$line" ]; do
+            line="${line%$'\r'}"
+            [ -z "$line" ] && continue
+            [[ "$line" =~ ^[[:space:]]*# ]] && continue
+
+            if [[ "$line" != *=* ]]; then
+              echo "::warning::Skipping invalid PROD_SECRET line (expected key=value)."
+              continue
+            fi
+
+            key="${line%%=*}"
+            value="${line#*=}"
+            key="${key#"${key%%[![:space:]]*}"}"
+            key="${key%"${key##*[![:space:]]}"}"
+            parsed["$key"]="$value"
+          done <<< "$PROD_SECRET"
+
           required=(FIREBASE_PROJECT_ID FIREBASE_CLIENT_EMAIL FIREBASE_PRIVATE_KEY MOLIT_SERVICE_KEY)
           for key in "${required[@]}"; do
-            if [ -z "${!key}" ]; then
+            value="${parsed[$key]:-}"
+            if [ -z "$value" ]; then
               echo "::error::Missing secret: $key"
-              echo "::error::Set this under Settings > Secrets and variables > Actions."
+              echo "::error::Set this in PROD_SECRET as '$key=...'."
               exit 1
             fi
+
+            if [ "$key" = "FIREBASE_PRIVATE_KEY" ]; then
+              value="${value//\\n/$'\n'}"
+            fi
+
+            echo "::add-mask::$value"
+            {
+              echo "$key<<EOF"
+              echo "$value"
+              echo "EOF"
+            } >> "$GITHUB_ENV"
           done
 
       - name: Setup Node.js


### PR DESCRIPTION
### Motivation
- Consolidate multiple repository secrets into a single `PROD_SECRET` to simplify CI secret management and allow storing multi-line private keys in one place.
- Keep downstream steps unchanged by mapping parsed keys back to the original environment variable names used by the workflow.

### Description
- Replace individual env entries with a single `PROD_SECRET` in `.github/workflows/test-data-collection.yml` and add a `Load and validate secrets` step to the job.
- Parse `PROD_SECRET` as lines in `key=value` format, ignoring blank lines and comments and warning on invalid lines.
- Validate required keys `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`, and `MOLIT_SERVICE_KEY`, unescape `\n` in `FIREBASE_PRIVATE_KEY`, mask values with `::add-mask::`, and export each value into `$GITHUB_ENV` via heredoc so later steps see the original variable names.
- Fail fast with clear error messages that instruct how to set missing keys inside `PROD_SECRET`.

### Testing
- Ran `git diff --check` which reported no issues.
- Reviewed the updated workflow file with `nl -ba .github/workflows/test-data-collection.yml` to confirm the parsing, masking, newline unescaping, and `$GITHUB_ENV` injection logic are present and correct.
- Performed a diff review of the workflow to verify the original behavior is preserved for subsequent steps that expect the individual secret variables.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d5b2ab1688332863add7ff3ba9a30)