### PR TITLE
Harden PROD_SECRET key parsing in test-data-collection workflow

### DIFF
--- a/.github/workflows/test-data-collection.yml
+++ b/.github/workflows/test-data-collection.yml
@@ -84,6 +84,21 @@ jobs:
               key="${key#"${key%%[![:space:]]*}"}"
               key="${key%"${key##*[![:space:]]}"}"
 
+              # Tolerate accidental wrapping characters when PROD_SECRET is pasted from
+              # array-like snippets (e.g. [KEY=value]).
+              key="${key#[}"
+              key="${key%]}"
+              key="${key#\"}"
+              key="${key%\"}"
+              key="${key#\'}"
+              key="${key%\'}"
+
+              if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+                ((skipped_count+=1))
+                echo "::warning::Skipping PROD_SECRET line ${line_number} due to invalid key '$key'."
+                continue
+              fi
+
               # Strip optional wrapping quotes from values in pasted .env blocks.
               if [[ "$value" =~ ^\".*\"$ ]]; then
                 value="${value:1:${#value}-2}"


### PR DESCRIPTION
### Motivation
- The workflow's secret loader could fail when `PROD_SECRET` lines contain accidental wrapper characters (e.g. `[FIREBASE_CLIENT_EMAIL=...]`), causing required secrets like `FIREBASE_CLIENT_EMAIL` to be reported missing. 
- Make the parsing more tolerant and fail-safe so pasted multi-line secret blobs don't poison required-secret lookups.

### Description
- Normalize parsed key names by stripping common accidental wrappers `[]`, `"` and `\'` before use. 
- Add key-name validation using `^[A-Za-z_][A-Za-z0-9_]*$` so malformed keys are skipped with a warning instead of injecting invalid keys into the parsed map. 
- Changes are confined to the `Load and validate secrets` step in `.github/workflows/test-data-collection.yml`.

### Testing
- Executed a local parser repro script that feeds a `PROD_SECRET` containing a bracket-wrapped entry and confirmed all four required keys are parsed correctly, and the script exited successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d6227e7c08332aea04edbffe3bcaf)