### PR TITLE
Rollback MOLIT default URL and harden collector parsing to avoid padStart crash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 FIREBASE_PROJECT_ID=your-project-id
 FIREBASE_CLIENT_EMAIL=firebase-adminsdk-xxxx@your-project-id.iam.gserviceaccount.com
 FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
-MOLIT_SERVICE_KEY=your_data_go_kr_service_key
+MOLIT_SERVICE_KEY=your_data_go_kr_service_key_decoding
 MOLIT_API_BASE=https://apis.data.go.kr/1613000/RTMSDataSvcAptTradeDev/getRTMSDataSvcAptTradeDev

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ cp .env.example .env
 - `FIREBASE_CLIENT_EMAIL`
 - `FIREBASE_PRIVATE_KEY`
 - `MOLIT_SERVICE_KEY`
+- `MOLIT_API_BASE` (선택, 기본값: `https://apis.data.go.kr/1613000/RTMSDataSvcAptTradeDev/getRTMSDataSvcAptTradeDev`)
+
+`MOLIT_SERVICE_KEY`는 **일반 인증키(Decoding)** 값을 권장합니다.
+만약 공공데이터포털의 Encoding 키를 넣어도 실행 시 1회 decode 후 요청하도록 처리되어 있습니다.
 
 ### 4.2 설치/빌드
 

--- a/src/collector/molitCollector.ts
+++ b/src/collector/molitCollector.ts
@@ -11,9 +11,63 @@ const toNumber = (raw: string): number => Number(raw.replaceAll(",", "").trim())
 
 const pad2 = (value: string): string => value.padStart(2, "0");
 
-const makeTradeId = (row: RawTradeRow): string => {
+const normalizeServiceKey = (serviceKey: string): string => {
+  if (!serviceKey.includes("%")) {
+    return serviceKey;
+  }
+
+  try {
+    return decodeURIComponent(serviceKey);
+  } catch {
+    return serviceKey;
+  }
+};
+
+const asString = (value: unknown): string | undefined => {
+  if (value === null || value === undefined) return undefined;
+  const normalized = String(value).trim();
+  return normalized.length ? normalized : undefined;
+};
+
+const pickValue = (row: Record<string, unknown>, keys: string[]): string | undefined => {
+  for (const key of keys) {
+    const value = asString(row[key]);
+    if (value) return value;
+  }
+  return undefined;
+};
+
+const normalizeRow = (row: Record<string, unknown>): RawTradeRow | null => {
+  const legalDong = pickValue(row, ["법정동", "법정동명", "umdNm"]);
+  const apartment = pickValue(row, ["아파트", "아파트명", "aptNm"]);
+  const year = pickValue(row, ["년", "년도", "dealYear"]);
+  const month = pickValue(row, ["월", "dealMonth"]);
+  const day = pickValue(row, ["일", "dealDay"]);
+  const area = pickValue(row, ["전용면적", "excluUseAr"]);
+  const amount = pickValue(row, ["거래금액", "거래금액(만원)", "dealAmount"]);
+  const floor = pickValue(row, ["층", "floor"]);
+
+  if (!legalDong || !apartment || !year || !month || !day || !area || !amount || !floor) {
+    return null;
+  }
+
+  return {
+    법정동: legalDong,
+    아파트: apartment,
+    년: year,
+    월: month,
+    일: day,
+    전용면적: area,
+    거래금액: amount,
+    층: floor,
+    지번: pickValue(row, ["지번", "jibun"]) ?? "",
+    지역코드: pickValue(row, ["지역코드", "지역코드값", "sggCd"]) ?? "",
+  };
+};
+
+const makeTradeId = (row: RawTradeRow, districtCode: string): string => {
   return [
-    row.지역코드,
+    row.지역코드 || districtCode,
     row.법정동,
     row.아파트,
     row.년,
@@ -35,7 +89,10 @@ const parseRows = (xml: string): RawTradeRow[] => {
     return [];
   }
 
-  return Array.isArray(items) ? items : [items];
+  const rows = Array.isArray(items) ? items : [items];
+  return rows
+    .map((row) => normalizeRow((row ?? {}) as Record<string, unknown>))
+    .filter((row): row is RawTradeRow => row !== null);
 };
 
 export const collectTradesByMonth = async (
@@ -48,7 +105,7 @@ export const collectTradesByMonth = async (
   }
 
   const url = new URL(config.molitApiBase);
-  url.searchParams.set("serviceKey", config.molitServiceKey);
+  url.searchParams.set("serviceKey", normalizeServiceKey(config.molitServiceKey));
   url.searchParams.set("LAWD_CD", districtCode);
   url.searchParams.set("DEAL_YMD", yearMonth);
   url.searchParams.set("numOfRows", "999");
@@ -71,7 +128,7 @@ export const collectTradesByMonth = async (
     const tradeDate = `${row.년}-${pad2(row.월)}-${pad2(row.일)}`;
 
     return {
-      id: makeTradeId(row),
+      id: makeTradeId(row, districtCode),
       region,
       districtCode,
       legalDong: row.법정동,


### PR DESCRIPTION
### Motivation
- Restore the previous DEV MOLIT endpoint because review feedback indicated the original rollback was incorrect and the DEV URL must remain the default.
- Prevent runtime crashes seen when collecting data where API rows omit or use alternate names for `월`/`일` fields which caused `padStart` to throw.
- Keep the existing service-key normalization to support callers that provide an encoded `MOLIT_SERVICE_KEY`.

### Description
- Rolled back `MOLIT_API_BASE` default to the Dev endpoint in `src/lib/config.ts` and aligned `.env.example` and `README.md` accordingly.
- Reworked `src/collector/molitCollector.ts` to add `normalizeServiceKey`, `asString`, `pickValue`, and `normalizeRow` helpers that tolerate alternate field names and skip malformed rows.
- Updated trade ID generation to use the incoming `districtCode` as a fallback when `지역코드` is missing and adjusted mapping to produce robust `TradeRecord` values.
- Kept XML parsing with `fast-xml-parser` but now normalize rows before mapping so missing or renamed fields no longer cause `padStart`/`undefined` errors.

### Testing
- Ran `npm run check` (TypeScript compile check) which completed successfully.
- Basic local validation of the collector behavior was performed by exercising the parsing flow against expected XML shapes and confirmed no `padStart` crash occurred.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d635fd7308332a2121318ad891e07)