### PR TITLE
Refactor Firestore storage to grouped apartment documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 - ChatGPT가 자연어 질의 수신
 - MCP tool 호출
-- Firestore 집계/거래 데이터 조회
+- Firestore 그룹 집계/거래 데이터 조회
 - 결과를 텍스트/구조화 데이터로 반환
 
 즉, 이 저장소는 ChatGPT Apps에서 확장 가능한 **백엔드(툴 서버) 코어**입니다.
@@ -35,8 +35,8 @@
         |
         v
 [Firestore]
-  - apt_transactions
-  - apt_monthly_aggregates
+  - apt_transaction_groups
+  - apt_monthly_aggregate_groups
         |
         v
  MCP Server (src/mcp/server.ts)
@@ -168,29 +168,25 @@ npm run dev:apps
 
 ## 5) Firestore 스키마
 
-### apt_transactions
-- `id`: 거래 고유 ID
+### apt_transaction_groups
+- `id`: 그룹 문서 ID (`region|districtCode|yearMonth|legalDong|apartmentName`)
 - `region`: 서울/경기/인천
 - `districtCode`: 법정동 코드
+- `yearMonth`: YYYYMM
+- `groupKey`: `legalDong|apartmentName`
 - `legalDong`: 법정동
 - `apartmentName`: 아파트명
-- `areaM2`: 전용면적
-- `priceKrw`: 원화 가격
-- `floor`: 층
-- `tradedAt`: YYYY-MM-DD
-- `source`: MOLIT_RTMS
-- `collectedAt`: 수집 시각
+- `trades`: 동일 단지/주소 그룹의 거래 배열
+- `txCount`: 그룹 거래 건수
+- `lastTradedAt`: 그룹 내 최신 거래일
 
-### apt_monthly_aggregates
+### apt_monthly_aggregate_groups
+- `id`: 그룹 문서 ID (`region|districtCode|yearMonth`)
 - `region`
 - `districtCode`
-- `apartmentName`
 - `yearMonth`: YYYYMM
-- `avgPriceKrw`
-- `medianPriceKrw`
-- `minPriceKrw`
-- `maxPriceKrw`
-- `txCount`
+- `items`: 단지별 월 집계 배열 (`apartmentName`, `avgPriceKrw`, `txCount` 등 포함)
+- `totalTxCount`: 문서 전체 거래 건수
 
 ---
 

--- a/src/apps/quickstart/server.ts
+++ b/src/apps/quickstart/server.ts
@@ -59,9 +59,9 @@ registerAppTool(
       "openai/outputTemplate": UI_TEMPLATE_URI,
     },
   },
-  async ({ region, fromYm, toYm, limit }) => {
+  async ({ region, fromYm, toYm, limit }: { region?: "서울" | "경기" | "인천"; fromYm: string; toYm: string; limit: number }) => {
     let query = firestore
-      .collection("apt_monthly_aggregates")
+      .collection("apt_monthly_aggregate_groups")
       .where("yearMonth", ">=", fromYm)
       .where("yearMonth", "<=", toYm)
       .orderBy("yearMonth", "desc")
@@ -72,16 +72,20 @@ registerAppTool(
     }
 
     const snapshot = await query.get();
-    const rows = snapshot.docs.map((doc) => {
-      const data = doc.data();
-      return {
-        yearMonth: data.yearMonth,
-        region: data.region,
-        apartmentName: data.apartmentName,
-        avgPriceKrw: data.avgPriceKrw,
-        txCount: data.txCount,
-      };
-    });
+    const rows = snapshot.docs
+      .flatMap((doc) => {
+        const data = doc.data();
+        return Array.isArray(data.items) ? data.items : [];
+      })
+      .sort((a, b) => String(b.yearMonth).localeCompare(String(a.yearMonth)))
+      .slice(0, limit)
+      .map((item) => ({
+        yearMonth: item.yearMonth,
+        region: item.region,
+        apartmentName: item.apartmentName,
+        avgPriceKrw: item.avgPriceKrw,
+        txCount: item.txCount,
+      }));
 
     return {
       content: [

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,17 +1,48 @@
 import { firestore } from "./firebase.js";
-import { MonthlyAggregate, TradeRecord } from "./types.js";
+import { MonthlyAggregate, MonthlyAggregateGroupDocument, TradeGroupDocument, TradeRecord } from "./types.js";
 
-const tradesCollection = firestore.collection("apt_transactions");
-const monthlyCollection = firestore.collection("apt_monthly_aggregates");
+const tradeGroupCollection = firestore.collection("apt_transaction_groups");
+const monthlyGroupCollection = firestore.collection("apt_monthly_aggregate_groups");
+
+const normalizeGroupKey = (value: string): string => value.replaceAll("|", " ").trim();
+
+const makeTradeGroupId = (record: TradeRecord): string => {
+  const ym = record.tradedAt.slice(0, 7).replace("-", "");
+  const groupKey = `${normalizeGroupKey(record.legalDong)}|${normalizeGroupKey(record.apartmentName)}`;
+  return `${record.region}|${record.districtCode}|${ym}|${groupKey}`;
+};
 
 export const upsertTrades = async (records: TradeRecord[]): Promise<void> => {
   if (records.length === 0) return;
 
-  const batch = firestore.batch();
+  const bucket = new Map<string, TradeRecord[]>();
 
   for (const record of records) {
-    const ref = tradesCollection.doc(record.id);
-    batch.set(ref, record, { merge: true });
+    const groupId = makeTradeGroupId(record);
+    const list = bucket.get(groupId) ?? [];
+    list.push(record);
+    bucket.set(groupId, list);
+  }
+
+  const batch = firestore.batch();
+
+  for (const [id, trades] of bucket.entries()) {
+    const first = trades[0];
+    const sortedByDate = [...trades].sort((a, b) => b.tradedAt.localeCompare(a.tradedAt));
+    const doc: TradeGroupDocument = {
+      id,
+      region: first.region,
+      districtCode: first.districtCode,
+      yearMonth: first.tradedAt.slice(0, 7).replace("-", ""),
+      groupKey: `${normalizeGroupKey(first.legalDong)}|${normalizeGroupKey(first.apartmentName)}`,
+      legalDong: first.legalDong,
+      apartmentName: first.apartmentName,
+      trades: sortedByDate,
+      txCount: trades.length,
+      lastTradedAt: sortedByDate[0]?.tradedAt ?? "",
+    };
+
+    batch.set(tradeGroupCollection.doc(id), doc, { merge: true });
   }
 
   await batch.commit();
@@ -59,11 +90,29 @@ export const makeMonthlyAggregates = (records: TradeRecord[]): MonthlyAggregate[
 export const upsertMonthlyAggregates = async (aggregates: MonthlyAggregate[]): Promise<void> => {
   if (aggregates.length === 0) return;
 
-  const batch = firestore.batch();
+  const bucket = new Map<string, MonthlyAggregate[]>();
 
   for (const item of aggregates) {
-    const id = `${item.region}|${item.districtCode}|${item.apartmentName}|${item.yearMonth}`;
-    batch.set(monthlyCollection.doc(id), item, { merge: true });
+    const id = `${item.region}|${item.districtCode}|${item.yearMonth}`;
+    const list = bucket.get(id) ?? [];
+    list.push(item);
+    bucket.set(id, list);
+  }
+
+  const batch = firestore.batch();
+
+  for (const [id, items] of bucket.entries()) {
+    const first = items[0];
+    const doc: MonthlyAggregateGroupDocument = {
+      id,
+      region: first.region,
+      districtCode: first.districtCode,
+      yearMonth: first.yearMonth,
+      items,
+      totalTxCount: items.reduce((acc, item) => acc + item.txCount, 0),
+    };
+
+    batch.set(monthlyGroupCollection.doc(id), doc, { merge: true });
   }
 
   await batch.commit();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -36,3 +36,25 @@ export interface MonthlyAggregate {
   maxPriceKrw: number;
   txCount: number;
 }
+
+export interface TradeGroupDocument {
+  id: string;
+  region: string;
+  districtCode: string;
+  yearMonth: string;
+  groupKey: string;
+  legalDong: string;
+  apartmentName: string;
+  trades: TradeRecord[];
+  txCount: number;
+  lastTradedAt: string;
+}
+
+export interface MonthlyAggregateGroupDocument {
+  id: string;
+  region: string;
+  districtCode: string;
+  yearMonth: string;
+  items: MonthlyAggregate[];
+  totalTxCount: number;
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -26,7 +26,7 @@ server.registerTool(
     inputSchema: searchInputSchema,
   },
   async (input) => {
-    let query = firestore.collection("apt_monthly_aggregates")
+    let query = firestore.collection("apt_monthly_aggregate_groups")
       .where("yearMonth", ">=", input.fromYm)
       .where("yearMonth", "<=", input.toYm)
       .orderBy("yearMonth", "asc")
@@ -40,12 +40,14 @@ server.registerTool(
       query = query.where("districtCode", "==", input.districtCode);
     }
 
-    if (input.apartmentName) {
-      query = query.where("apartmentName", "==", input.apartmentName);
-    }
-
     const snapshot = await query.get();
-    const docs = snapshot.docs.map((doc) => doc.data());
+    const docs = snapshot.docs
+      .flatMap((doc) => {
+        const data = doc.data();
+        return Array.isArray(data.items) ? data.items : [];
+      })
+      .filter((item) => !input.apartmentName || item.apartmentName === input.apartmentName)
+      .sort((a, b) => String(a.yearMonth).localeCompare(String(b.yearMonth)));
 
     if (docs.length === 0) {
       return {
@@ -107,14 +109,22 @@ server.registerTool(
     },
   },
   async (input) => {
-    let query = firestore.collection("apt_transactions").orderBy("tradedAt", "desc").limit(input.limit);
+    let query = firestore.collection("apt_transaction_groups")
+      .orderBy("lastTradedAt", "desc")
+      .limit(Math.max(30, input.limit * 4));
 
     if (input.region) query = query.where("region", "==", input.region);
     if (input.districtCode) query = query.where("districtCode", "==", input.districtCode);
-    if (input.apartmentName) query = query.where("apartmentName", "==", input.apartmentName);
 
     const snapshot = await query.get();
-    const rows = snapshot.docs.map((doc) => doc.data());
+    const rows = snapshot.docs
+      .flatMap((doc) => {
+        const data = doc.data();
+        return Array.isArray(data.trades) ? data.trades : [];
+      })
+      .filter((row) => !input.apartmentName || row.apartmentName === input.apartmentName)
+      .sort((a, b) => String(b.tradedAt).localeCompare(String(a.tradedAt)))
+      .slice(0, input.limit);
 
     return {
       content: [


### PR DESCRIPTION
### Motivation

- The collected data is immutable and reads should be optimized to reduce Firestore read cost.  
- Group transactions by the minimal address/apartment unit per month so a single document can serve many queries.  
- Expose the new grouped representation to the MCP/App query layers so clients read fewer documents for the same information.

### Description

- Introduced grouped Firestore collections: `apt_transaction_groups` (grouped by `region|districtCode|yearMonth|legalDong|apartmentName`) and `apt_monthly_aggregate_groups` (grouped by `region|districtCode|yearMonth`).
- Added group document types `TradeGroupDocument` and `MonthlyAggregateGroupDocument` in `src/lib/types.ts` and updated code to use them.
- Reworked ingestion/writes in `src/lib/store.ts` to bucket incoming `TradeRecord[]` and `MonthlyAggregate[]` by group id and upsert group documents containing `trades`/`items`, `txCount`, and `lastTradedAt` instead of many fine-grained docs.
- Updated MCP and Apps quickstart servers (`src/mcp/server.ts`, `src/apps/quickstart/server.ts`) to read the grouped collections and `flatMap`/filter/sort the embedded arrays in memory, and updated `README.md` to document the new Firestore schema.

### Testing

- Ran `npm run check` (TypeScript type check) and it failed due to environment/module resolution complaining about missing module/type declarations for `@modelcontextprotocol/ext-apps/server` in this environment.  
- Ran `npm run build` and it failed for the same module/type resolution reason, preventing a full build verification in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d8c87b62083328cbed308de06e96a)